### PR TITLE
Expose `AddressIter` and `PriorityIter`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ mod stream_once;
 mod routing;
 mod union;
 
-pub use address::{Address, AddressBuilder, WeightedSet};
+pub use address::{Address, AddressBuilder, AddressIter, PriorityIter, WeightedSet};
 pub use resolver::Resolver;
 pub use error::Error;
 pub use mem::{MemResolver, StaticStream};


### PR DESCRIPTION
It's impossible to spell out the return type of `Address::iter` or `WeightedSet::addresses` at the moment. This fixes it.